### PR TITLE
Fix required override keyword for two functions

### DIFF
--- a/McPicker/Classes/McPickerBarButtonItem.swift
+++ b/McPicker/Classes/McPickerBarButtonItem.swift
@@ -60,11 +60,11 @@ open class McPickerBarButtonItem: UIBarButtonItem {
         return self.init(barButtonSystemItem: barButtonSystemItem, target: mcPicker, action: #selector(McPicker.cancel))
     }
 
-    public class func flexibleSpace() -> McPickerBarButtonItem {
+    public override class func flexibleSpace() -> McPickerBarButtonItem {
         return self.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
     }
 
-    public class func fixedSpace(width: CGFloat) -> McPickerBarButtonItem {
+    public override class func fixedSpace(width: CGFloat) -> McPickerBarButtonItem {
         let fixedSpace =  self.init(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         fixedSpace.width = width
         return fixedSpace


### PR DESCRIPTION
This seems to be a requirement in Swift 5 or Xcode 12?